### PR TITLE
Fix the "Invariant Violation "

### DIFF
--- a/ios/rn_starter_kit/AppDelegate.m
+++ b/ios/rn_starter_kit/AppDelegate.m
@@ -33,7 +33,7 @@ static void InitializeFlipper(UIApplication *application) {
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                                   moduleName:@"rn_starter_kit"
+                                                   moduleName:@"StarterApp"
                                             initialProperties:nil];
 
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];


### PR DESCRIPTION
Android is fine but running the app on iOS 14.3 simulator encounters this error.
This link suggests that the module name needs to match the Registered App Component in the AppDelegate.m.