### PR TITLE
fix: bottom tab navigation icons not showing

### DIFF
--- a/src/navigations/AppNavigation.js
+++ b/src/navigations/AppNavigation.js
@@ -68,7 +68,7 @@ const TabNavigator = createBottomTabNavigator(
     Home: { screen: HomeStack }
   },
   {
-    navigationOptions: ({ navigation }) => ({
+    defaultNavigationOptions: ({ navigation }) => ({
       tabBarIcon: ({ focused, tintColor }) => {
         const { routeName } = navigation.state;
         let iconName;


### PR DESCRIPTION
Bottom Tab navigation icon is not showing on my android. Changing **navigationOptions** to **defaultNavigationOptions** fixed it.